### PR TITLE
RUN chmod +x on entrypoint.sh within Dockerfile to fix permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN sed -i -e s/host-pnp/host-perf/g /omd/sites/default/etc/icinga2/conf.d/hosts
 EXPOSE 80 443 8086
 
 COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 RUN sed -i 's/\r//' /entrypoint.sh #Just for Windowssystems...
 
 COPY ./services.conf /omd/sites/default/etc/icinga2/conf.d/services.conf


### PR DESCRIPTION
When cloning from the repository, entrypoint.sh loses its execution bit, which in turn leads to the following error on docker run:
```
docker: Error response from daemon: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"/entrypoint.sh\\\": permission denied\"\n".
```
We simply add a `RUN chmod +x /entrypoint.sh` to the Dockerfile to prevent this.

This fixes Griesbacher/omd-grafana-container#1